### PR TITLE
ChatSpaceの投稿機能を非同期通信で行う

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+#gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,9 +221,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -264,7 +261,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,66 @@
+$(function(){ 
+  function buildHTML(message){
+   if ( message.image ) {
+     var html =
+      `<div class="message">
+         <div class="upper-message">
+           <div class="upper-message__user-name">
+             ${message.user_name}
+           </div>
+           <div class="upper-message__date">
+             ${message.created_at}
+           </div>
+         </div>
+         <div class="lower-message">
+           <p class="lower-message__content">
+             ${message.content}
+           </p>
+         </div>
+         <img src=${message.image} >
+       </div>`
+     return html;
+   } else {
+     var html =
+      `<div class="message">
+         <div class="upper-message">
+           <div class="upper-message__user-name">
+             ${message.user_name}
+           </div>
+           <div class="upper-message__date">
+             ${message.created_at}
+           </div>
+         </div>
+         <div class="lower-message">
+           <p class="lower-message__content">
+             ${message.content}
+           </p>
+         </div>
+       </div>`
+     return html;
+   };
+ }
+$('#new_message').on('submit', function(e){
+ e.preventDefault();
+ var formData = new FormData(this);
+ var url = $(this).attr('action')
+ $.ajax({
+   url: url,
+   type: "POST",
+   data: formData,
+   dataType: 'json',
+   processData: false,
+   contentType: false
+ })
+  .done(function(data){
+    var html = buildHTML(data);
+    $('.messages').append(html);      
+    $('form')[0].reset();
+    $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+    $('.form__submit').prop('disabled', false);
+  })
+  .fail(function() {
+    alert("メッセージ送信に失敗しました");
+    $('.form__submit').prop('disabled', false);
+  });
+})
+}); 

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -56,10 +56,11 @@ $('#new_message').on('submit', function(e){
     $('.messages').append(html);      
     $('form')[0].reset();
     $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
-    $('.form__submit').prop('disabled', false);
   })
   .fail(function() {
     alert("メッセージ送信に失敗しました");
+  })
+  .always(function() {
     $('.form__submit').prop('disabled', false);
   });
 })

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -57,10 +57,12 @@
           margin-top: 20px;
           font-size: 15px;
           margin-bottom: 5px;
+          color: $white;
         }
         p.group__group-message {
           font-size: 11px;
           margin-bottom: 40px;
+          color: $white;
         }
       }
     }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,9 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,8 +3,8 @@
   %head
     %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
     %title ChatSpace
-    = stylesheet_link_tag    'application', media: 'all',data:{turbolinks:{track:true}}
-    = javascript_include_tag 'application', data: {turbolinks:{track:true}}
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
     = csrf_meta_tags
   %body
     = render 'layouts/notifications'

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.content
+json.image @message.image_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ Bundler.require(*Rails.groups)
 
 module ChatSpace
   class Application < Rails::Application
+    config.time_zone = 'Tokyo'
     config.generators do |g|
       g.stylesheets false
       g.javascripts false


### PR DESCRIPTION
#What
JSを追加してメッセージの送信を非同期で行えるようにする。

#Why
メッセージを送信するたびに送信画面にリダイレクトさせず、
送信の処理が素早く行えるため、見やすくなる。

実装動画GIF
https://gyazo.com/e83df60a8f3b6eab67a14b6a754acc0b